### PR TITLE
PG-backed full-text search

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -289,6 +289,9 @@ MAX_POLL_OPTION_CHARS=100
 # - classic: searches only a user's own statuses, favs, bookmarks, and mentions
 # SEARCH_SCOPE=public
 
+# Use PostgreSQL for full-text search if Elasticsearch is not installed
+# PG_FULL_TEXT_SEARCH_ENABLED=true
+
 # Maximum custom emoji file sizes
 # If undefined or smaller than MAX_EMOJI_SIZE, the value
 # of MAX_EMOJI_SIZE will be used for MAX_REMOTE_EMOJI_SIZE

--- a/config/initializers/search_scope.rb
+++ b/config/initializers/search_scope.rb
@@ -9,4 +9,6 @@ Rails.application.configure do
   else
     :classic
   end
+
+  config.x.pg_full_text_search_enabled = ENV['PG_FULL_TEXT_SEARCH_ENABLED'] == 'true'
 end

--- a/db/migrate/20221219222648_add_full_text_index_to_statuses.rb
+++ b/db/migrate/20221219222648_add_full_text_index_to_statuses.rb
@@ -1,0 +1,13 @@
+class AddFullTextIndexToStatuses < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :statuses,
+              "(to_tsvector('english', spoiler_text) || to_tsvector('english', text))",
+              name: 'index_statuses_full_text',
+              where: 'deleted_at is null and reblog_of_id is null and visibility in (%{public}, %{unlisted})' %
+                Status.visibilities.symbolize_keys,
+              algorithm: :concurrently,
+              using: 'gin'
+  end
+end


### PR DESCRIPTION
Don't want to run Elasticsearch or OpenSearch but still want full-text search? PostgreSQL has you covered and so do I. This is based on previous work in PR #2 but intended to be as cheap as possible compared to ES. If there's a shortcut to do less work without compromising privacy, I took it.

If you try this, please let me know how it goes. If you run into problems, let me know here.

Current installation instructions:
- Apply all the changes in PR #2 and this PR.
  - If you're running a PG version before 11, replace `websearch_to_tsquery` in `app/services/search_service.rb` with the slightly less useful `plainto_tsquery`.
- In your `.env.production`:
  - Unset `ES_ENABLED` or set `ES_ENABLED=false`.
  - Set `PG_FULL_TEXT_SEARCH_ENABLED=true`.
  - Set `SEARCH_SCOPE=public` or `SEARCH_SCOPE=public_or_unlisted`. (The default, `classic`, is not recommended; see below.)
- Run the included migration with `RAILS_ENV=production bundle exec rails db:migrate`. This will add a full-text index for all public or unlisted statuses in your database, and will take several minutes, but is quite a lot faster than reindexing your entire database to ES.
- `systemctl restart mastodon-web.service mastodon-sidekiq.service` to reload changed code.
- You **do not** need to run the `tootctl search deploy` command from PR #2, which only applies to Elasticsearch indexes.

Known major limitations:
- This has not seriously been performance-tested. Volunteers welcome.
- There's no point to this patch if you have ES on, because it'll use ES preferentially to PG. Turn ES off before trying it.
- Search only covers words in the post body and CW, not media attachment alt text or poll text.
- Unlike with ES, the `public` and `public_or_unlisted` search scopes does not also search your favs, boosts, or bookmarks of private posts or DMs. You only get public and unlisted posts.

Known minor limitations:
- HTML is not filtered out because doing that in PG SQL is a fool's errand. If you search for `href` or other common tags or attributes, you will probably get a lot of useless results.
- Text processing assumes the text is English. This is a limitation in common with [vanilla Mastodon full-text search](https://docs.joinmastodon.org/admin/optional/elasticsearch/#search-optimization-for-other-languages). If most of your text is in a different language, read the [PG docs for full-text search](https://www.postgresql.org/docs/15/textsearch.html) and then replace `'english'` in the text of this patch with some other region configuration.
- I haven't figured out how to make migrations conditional on app config. I'm honestly not sure if you're supposed to. This means that if you install this patch and run the migration, you are paying the costs of maintaining the `index_statuses_full_text` index even if you later turn off `PG_FULL_TEXT_SEARCH_ENABLED`. If you need to do that for some reason, just drop the index by hand.
- A subset of the `classic` (vanilla Mastodon default) search scope is kind of supported but not really that useful: it only searches the logged-in user's own public or unlisted posts, which includes private posts and DMs but not favs, boosts, or bookmarks of other user's posts. The query will degrade to an index scan, which isn't great perf-wise.
- [Vanilla Mastodon advanced search syntax](https://docs.joinmastodon.org/user/network/#search) is not supported. You get [something vaguely like it from `websearch_to_tsquery`](https://www.postgresql.org/docs/15/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES), but the `+` and `from:` operators are not supported, and all search terms that aren't prefixed with `-` are treated as required (as if they were prefixed with `+` in vanilla search syntax). You can explicitly `or` terms where you want one or the other but not both, but honestly, who does that?